### PR TITLE
Support for Authentication and Proxy setting in HttpClient

### DIFF
--- a/Raygun.Druid4Net.IntegrationTests/App.config
+++ b/Raygun.Druid4Net.IntegrationTests/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="druid.broker.host" value="http://localhost"/>
+    <add key="druid.broker.host" value="http://localhost:8082"/>
   </appSettings>
 </configuration>

--- a/Raygun.Druid4Net.IntegrationTests/Queries/TestQueryBase.cs
+++ b/Raygun.Druid4Net.IntegrationTests/Queries/TestQueryBase.cs
@@ -12,7 +12,12 @@ namespace Raygun.Druid4Net.IntegrationTests.Queries
 
     protected TestQueryBase()
     {
-      DruidClient = new DruidClient(new JilSerializer(), ConfigurationManager.AppSettings["druid.broker.host"]);
+      var options = new ConfigurationOptions()
+      {
+        JsonSerializer = new JilSerializer(),
+        ApiHostName = ConfigurationManager.AppSettings["druid.broker.host"]
+      };
+      DruidClient = new DruidClient(options);
     }
   }
 }

--- a/Raygun.Druid4Net.IntegrationTests/Queries/TestQueryBase.cs
+++ b/Raygun.Druid4Net.IntegrationTests/Queries/TestQueryBase.cs
@@ -15,7 +15,7 @@ namespace Raygun.Druid4Net.IntegrationTests.Queries
       var options = new ConfigurationOptions()
       {
         JsonSerializer = new JilSerializer(),
-        ApiHostName = ConfigurationManager.AppSettings["druid.broker.host"]
+        QueryApiBaseAddress = new Uri(ConfigurationManager.AppSettings["druid.broker.host"])
       };
       DruidClient = new DruidClient(options);
     }

--- a/Raygun.Druid4Net/Configuration/BasicAuthenticationCredentials.cs
+++ b/Raygun.Druid4Net/Configuration/BasicAuthenticationCredentials.cs
@@ -1,0 +1,11 @@
+namespace Raygun.Druid4Net
+{
+  public class BasicAuthenticationCredentials
+  {
+    public string Password { get; set; }
+    
+    public string Username { get; set; }
+
+    public override string ToString() => $"{Username}:{Password}";
+  }
+}

--- a/Raygun.Druid4Net/Configuration/ConfigurationOptions.cs
+++ b/Raygun.Druid4Net/Configuration/ConfigurationOptions.cs
@@ -1,20 +1,19 @@
+using System;
+
 namespace Raygun.Druid4Net
 {
   public class ConfigurationOptions
   {
     public ConfigurationOptions()
     {
-      ApiHostName = "http://localhost";
-      ApiPort = 8082;
-      ApiEndpoint = "druid/v2";
+      QueryApiBaseAddress = new Uri("http://localhost:8082");
+      QueryApiEndpoint = "druid/v2";
     }
 
-    public string ApiHostName { get; set; }
-
-    public int ApiPort { get; set; }
-
-    public string ApiEndpoint { get; set; }
+    public Uri QueryApiBaseAddress { get; set; }
     
+    public string QueryApiEndpoint { get; set; }
+
     public IJsonSerializer JsonSerializer { get; set; }
 
     public ProxySettings ProxySettings { get; set; }

--- a/Raygun.Druid4Net/Configuration/ConfigurationOptions.cs
+++ b/Raygun.Druid4Net/Configuration/ConfigurationOptions.cs
@@ -17,6 +17,8 @@ namespace Raygun.Druid4Net
     
     public IJsonSerializer JsonSerializer { get; set; }
 
+    public ProxySettings ProxySettings { get; set; }
+    
     public BasicAuthenticationCredentials BasicAuthenticationCredentials { get; set; }
   }
 }

--- a/Raygun.Druid4Net/Configuration/ConfigurationOptions.cs
+++ b/Raygun.Druid4Net/Configuration/ConfigurationOptions.cs
@@ -1,0 +1,22 @@
+namespace Raygun.Druid4Net
+{
+  public class ConfigurationOptions
+  {
+    public ConfigurationOptions()
+    {
+      ApiHostName = "http://localhost";
+      ApiPort = 8082;
+      ApiEndpoint = "druid/v2";
+    }
+
+    public string ApiHostName { get; set; }
+
+    public int ApiPort { get; set; }
+
+    public string ApiEndpoint { get; set; }
+    
+    public IJsonSerializer JsonSerializer { get; set; }
+
+    public BasicAuthenticationCredentials BasicAuthenticationCredentials { get; set; }
+  }
+}

--- a/Raygun.Druid4Net/Configuration/ProxySettings.cs
+++ b/Raygun.Druid4Net/Configuration/ProxySettings.cs
@@ -1,0 +1,15 @@
+namespace Raygun.Druid4Net
+{
+  public class ProxySettings
+  {
+    public string Address  { get; set; }
+    
+    public bool BypassOnLocal  { get; set; }
+    
+    public string Username { get; set; }
+    
+    public string Password { get; set; }
+
+    public override string ToString() => $"{Username}:{Password}";
+  }
+}

--- a/Raygun.Druid4Net/Configuration/ProxySettings.cs
+++ b/Raygun.Druid4Net/Configuration/ProxySettings.cs
@@ -1,8 +1,10 @@
+using System;
+
 namespace Raygun.Druid4Net
 {
   public class ProxySettings
   {
-    public string Address  { get; set; }
+    public Uri Address  { get; set; }
     
     public bool BypassOnLocal  { get; set; }
     

--- a/Raygun.Druid4Net/Configuration/ProxySettings.cs
+++ b/Raygun.Druid4Net/Configuration/ProxySettings.cs
@@ -9,7 +9,5 @@ namespace Raygun.Druid4Net
     public string Username { get; set; }
     
     public string Password { get; set; }
-
-    public override string ToString() => $"{Username}:{Password}";
   }
 }

--- a/Raygun.Druid4Net/DruidClient.cs
+++ b/Raygun.Druid4Net/DruidClient.cs
@@ -14,9 +14,8 @@ namespace Raygun.Druid4Net
       _configurationOptions = new ConfigurationOptions
       {
         JsonSerializer = jsonSerializer,
-        ApiHostName = hostName,
-        ApiPort = port,
-        ApiEndpoint = apiEndpoint,
+        QueryApiBaseAddress = new Uri($"{hostName}:{port}"),
+        QueryApiEndpoint = apiEndpoint,
       };
       _requester = new Requester(_configurationOptions);
     }
@@ -36,7 +35,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new TopNQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<TopNResult<TResponse>, TopNRequestData>(_configurationOptions.ApiEndpoint, request);
+      var result = await ExecuteQueryAsync<TopNResult<TResponse>, TopNRequestData>(_configurationOptions.QueryApiEndpoint, request);
 
       return result;
     }
@@ -50,7 +49,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new GroupByQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<GroupByResult<TResponse>, GroupByRequestData>(_configurationOptions.ApiEndpoint, request);
+      var result = await ExecuteQueryAsync<GroupByResult<TResponse>, GroupByRequestData>(_configurationOptions.QueryApiEndpoint, request);
 
       return result;
     }
@@ -64,7 +63,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new TimeseriesQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<TimeseriesResult<TResponse>, TimeseriesRequestData>(_configurationOptions.ApiEndpoint, request);
+      var result = await ExecuteQueryAsync<TimeseriesResult<TResponse>, TimeseriesRequestData>(_configurationOptions.QueryApiEndpoint, request);
 
       return result;
     }
@@ -78,7 +77,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new SelectQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<SelectResult<TResponse>, SelectRequestData>(_configurationOptions.ApiEndpoint, request);
+      var result = await ExecuteQueryAsync<SelectResult<TResponse>, SelectRequestData>(_configurationOptions.QueryApiEndpoint, request);
 
       return result;
     }
@@ -92,7 +91,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new SearchQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<SearchResult, SearchRequestData>(_configurationOptions.ApiEndpoint, request);
+      var result = await ExecuteQueryAsync<SearchResult, SearchRequestData>(_configurationOptions.QueryApiEndpoint, request);
 
       return result;
     }

--- a/Raygun.Druid4Net/DruidClient.cs
+++ b/Raygun.Druid4Net/DruidClient.cs
@@ -5,13 +5,26 @@ namespace Raygun.Druid4Net
 {
   public class DruidClient : IDruidClient
   {
-    private readonly Requester _requester;
-    private readonly string _apiEndpoint;
+    private readonly IRequester _requester;
+    private readonly ConfigurationOptions _configurationOptions;
 
+    [Obsolete("Use the constructor that takes a ConfigurationOptions instance")]
     public DruidClient(IJsonSerializer jsonSerializer, string hostName, int port = 8082, string apiEndpoint = "druid/v2")
     {
-      _requester = new Requester(jsonSerializer, hostName, port);
-      _apiEndpoint = apiEndpoint;
+      _configurationOptions = new ConfigurationOptions
+      {
+        JsonSerializer = jsonSerializer,
+        ApiHostName = hostName,
+        ApiPort = port,
+        ApiEndpoint = apiEndpoint,
+      };
+      _requester = new Requester(_configurationOptions);
+    }
+    
+    public DruidClient(ConfigurationOptions options, IRequester requester = null)
+    {
+      _configurationOptions = options;
+      _requester = requester ?? new Requester(options);
     }
 
     public IQueryResponse<TopNResult<TResponse>> TopN<TResponse>(Func<ITopNQueryDescriptor, ITopNQueryDescriptor> selector) where TResponse : class
@@ -23,7 +36,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new TopNQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<TopNResult<TResponse>, TopNRequestData>(_apiEndpoint, request);
+      var result = await ExecuteQueryAsync<TopNResult<TResponse>, TopNRequestData>(_configurationOptions.ApiEndpoint, request);
 
       return result;
     }
@@ -37,7 +50,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new GroupByQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<GroupByResult<TResponse>, GroupByRequestData>(_apiEndpoint, request);
+      var result = await ExecuteQueryAsync<GroupByResult<TResponse>, GroupByRequestData>(_configurationOptions.ApiEndpoint, request);
 
       return result;
     }
@@ -51,7 +64,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new TimeseriesQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<TimeseriesResult<TResponse>, TimeseriesRequestData>(_apiEndpoint, request);
+      var result = await ExecuteQueryAsync<TimeseriesResult<TResponse>, TimeseriesRequestData>(_configurationOptions.ApiEndpoint, request);
 
       return result;
     }
@@ -65,7 +78,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new SelectQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<SelectResult<TResponse>, SelectRequestData>(_apiEndpoint, request);
+      var result = await ExecuteQueryAsync<SelectResult<TResponse>, SelectRequestData>(_configurationOptions.ApiEndpoint, request);
 
       return result;
     }
@@ -79,7 +92,7 @@ namespace Raygun.Druid4Net
     {
       var request = selector(new SearchQueryDescriptor()).Generate();
 
-      var result = await ExecuteQueryAsync<SearchResult, SearchRequestData>(_apiEndpoint, request);
+      var result = await ExecuteQueryAsync<SearchResult, SearchRequestData>(_configurationOptions.ApiEndpoint, request);
 
       return result;
     }

--- a/Raygun.Druid4Net/Query/IRequester.cs
+++ b/Raygun.Druid4Net/Query/IRequester.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace Raygun.Druid4Net
+{
+  public interface IRequester
+  {
+    Task<IQueryResponse<TResponse>> PostAsync<TResponse, TRequest>(string endpoint, IDruidRequest<TRequest> request)
+      where TResponse : class
+      where TRequest : QueryRequestData;
+  }
+}

--- a/Raygun.Druid4Net/Query/Requester.cs
+++ b/Raygun.Druid4Net/Query/Requester.cs
@@ -32,7 +32,7 @@ namespace Raygun.Druid4Net
     private HttpClient CreateClient(ConfigurationOptions options)
     {
       var client = options.ProxySettings != null ? CreateClientWithProxyServer(options) : new HttpClient();
-      client.BaseAddress = new Uri($"{options.ApiHostName}:{options.ApiPort}");
+      client.BaseAddress = options.QueryApiBaseAddress;
       return client;
     }
 
@@ -46,7 +46,7 @@ namespace Raygun.Druid4Net
 #else
       var webProxy = new WebProxy
       {
-        Address = new Uri(options.ProxySettings.Address),
+        Address = options.ProxySettings.Address,
         BypassProxyOnLocal = options.ProxySettings.BypassOnLocal,
         UseDefaultCredentials = true
       };

--- a/Raygun.Druid4Net/Query/Requester.cs
+++ b/Raygun.Druid4Net/Query/Requester.cs
@@ -48,7 +48,7 @@ namespace Raygun.Druid4Net
       {
         Address = new Uri(options.ProxySettings.Address),
         BypassProxyOnLocal = options.ProxySettings.BypassOnLocal,
-        UseDefaultCredentials = false
+        UseDefaultCredentials = true
       };
 
       if (!string.IsNullOrEmpty(options.ProxySettings.Username) && !string.IsNullOrEmpty(options.ProxySettings.Password))

--- a/Raygun.Druid4Net/Query/Requester.cs
+++ b/Raygun.Druid4Net/Query/Requester.cs
@@ -47,8 +47,7 @@ namespace Raygun.Druid4Net
       var webProxy = new WebProxy
       {
         Address = options.ProxySettings.Address,
-        BypassProxyOnLocal = options.ProxySettings.BypassOnLocal,
-        UseDefaultCredentials = true
+        BypassProxyOnLocal = options.ProxySettings.BypassOnLocal
       };
 
       if (!string.IsNullOrEmpty(options.ProxySettings.Username) && !string.IsNullOrEmpty(options.ProxySettings.Password))

--- a/Raygun.Druid4Net/Raygun.Druid4Net.csproj
+++ b/Raygun.Druid4Net/Raygun.Druid4Net.csproj
@@ -20,23 +20,21 @@
     <PackageIconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</PackageIconUrl>
     <PackageTags>druid;druidio</PackageTags>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <DefineConstants>NETCORE;NETSTANDARD;NETSTANDARD1_6</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
     <DefineConstants>NET45;NETFULL</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net45'" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/Raygun.Druid4Net/Raygun.Druid4Net.csproj
+++ b/Raygun.Druid4Net/Raygun.Druid4Net.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net45;</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
   <!-- NuGet Options -->
@@ -35,7 +35,8 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds a configuration class to configure the Requester and HttpClient used in the Requester class. Initial support has been added to allow basic authentication details and proxy server settings to be configured.
For full flexibility the Requester class has been turned into an interface and a custom implementation can be supplied to the DruidClient.