### PR TITLE
Add limit offset to applicable queries

### DIFF
--- a/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/GroupByQueryDescriptorTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/GroupByQueryDescriptorTests.cs
@@ -27,7 +27,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       Assert.That(request.RequestData.Dimensions.OfType<DefaultDimension>().FirstOrDefault(d => d.Dimension == "test_dim1"), Is.Not.Null);
       Assert.That(request.RequestData.Dimensions.OfType<DefaultDimension>().FirstOrDefault(d => d.Dimension == "test_dim2"), Is.Not.Null);
     }
-
+    
     [Test]
     public void LimitIsSet_SetsLimitInBody()
     {
@@ -40,6 +40,24 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       Assert.IsNotNull(limit);
       Assert.That(limit.Type, Is.EqualTo("default"));
       Assert.That(limit.Limit, Is.EqualTo(10));
+      Assert.That(limit.Offset, Is.EqualTo(0));
+      Assert.That(limit.Columns.Count(), Is.EqualTo(1));
+      Assert.That(limit.Columns.First().Dimension, Is.EqualTo("test_dim1"));
+    }
+
+    [Test]
+    public void LimitIsSet_SetsLimitOffsetInBody()
+    {
+      var request = new GroupByQueryDescriptor()
+        .Limit(new DefaultLimitSpec(10, 20, new OrderByColumnSpec("test_dim1")))
+        .Generate();
+
+      var limit = request.RequestData.LimitSpec as DefaultLimitSpec;
+
+      Assert.IsNotNull(limit);
+      Assert.That(limit.Type, Is.EqualTo("default"));
+      Assert.That(limit.Limit, Is.EqualTo(10));
+      Assert.That(limit.Offset, Is.EqualTo(20));
       Assert.That(limit.Columns.Count(), Is.EqualTo(1));
       Assert.That(limit.Columns.First().Dimension, Is.EqualTo("test_dim1"));
     }

--- a/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/ScanQueryDescriptorTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/ScanQueryDescriptorTests.cs
@@ -60,6 +60,16 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
 
       Assert.That(request.RequestData.Limit, Is.EqualTo(500));
     }
+    
+    [Test]
+    public void OffsetIsSet_SetsOffsetInBody()
+    {
+      var request = new ScanQueryDescriptor()
+        .Offset(500)
+        .Generate();
+
+      Assert.That(request.RequestData.Offset, Is.EqualTo(500));
+    }
 
     [Test]
     public void OrderIsSet_SetsLimitInBody()

--- a/Raygun.Druid4Net/Fluent/Limits/DefaultLimitSpec.cs
+++ b/Raygun.Druid4Net/Fluent/Limits/DefaultLimitSpec.cs
@@ -7,12 +7,22 @@ namespace Raygun.Druid4Net
     public string Type => "default";
 
     public int Limit { get; }
+    
+    public int Offset { get; }
 
     public IEnumerable<OrderByColumnSpec> Columns { get; }
 
     public DefaultLimitSpec(int limit, params OrderByColumnSpec[] orderByColumns)
     {
       Limit = limit;
+      Offset = 0;
+      Columns = orderByColumns;
+    }
+
+    public DefaultLimitSpec(int limit, int offset = 0, params OrderByColumnSpec[] orderByColumns)
+    {
+      Limit = limit;
+      Offset = offset;
       Columns = orderByColumns;
     }
   }

--- a/Raygun.Druid4Net/Fluent/QueryDescriptors/IScanQueryDescriptor.cs
+++ b/Raygun.Druid4Net/Fluent/QueryDescriptors/IScanQueryDescriptor.cs
@@ -24,6 +24,8 @@ namespace Raygun.Druid4Net
     IScanQueryDescriptor BatchSize(int batchSize);
     
     IScanQueryDescriptor Limit(int limit);
+    
+    IScanQueryDescriptor Offset(int offset);
 
     IScanQueryDescriptor Order(OrderByDirection? order);
     

--- a/Raygun.Druid4Net/Fluent/QueryDescriptors/ScanQueryDescriptor.cs
+++ b/Raygun.Druid4Net/Fluent/QueryDescriptors/ScanQueryDescriptor.cs
@@ -7,6 +7,8 @@ namespace Raygun.Druid4Net
   {
     internal int? LimitValue;
 
+    internal int? OffsetValue;
+
     internal OrderByDirection? OrderValue;
 
     internal int? BatchSizeValue;
@@ -44,6 +46,12 @@ namespace Raygun.Druid4Net
     public IScanQueryDescriptor Limit(int limit)
     {
       LimitValue = limit;
+      return this;
+    }
+    
+    public IScanQueryDescriptor Offset(int offset)
+    {
+      OffsetValue = offset;
       return this;
     }
 

--- a/Raygun.Druid4Net/Fluent/Requests/ScanRequest.cs
+++ b/Raygun.Druid4Net/Fluent/Requests/ScanRequest.cs
@@ -8,7 +8,7 @@
     {
       var qd = queryDescriptor as ScanQueryDescriptor;
 
-      RequestData = new ScanRequestData(qd.DataSourceValue, qd.IntervalsValue, qd.FilterValue, qd.ContextValue, qd.ColumnsValue, qd.ResultFormatValue, qd.LimitValue, qd.OrderValue, qd.BatchSizeValue);
+      RequestData = new ScanRequestData(qd.DataSourceValue, qd.IntervalsValue, qd.FilterValue, qd.ContextValue, qd.ColumnsValue, qd.ResultFormatValue, qd.LimitValue, qd.OffsetValue, qd.OrderValue, qd.BatchSizeValue);
     }
   }
 }

--- a/Raygun.Druid4Net/Fluent/Requests/ScanRequestData.cs
+++ b/Raygun.Druid4Net/Fluent/Requests/ScanRequestData.cs
@@ -8,12 +8,13 @@ namespace Raygun.Druid4Net
     public IContextSpec Context { get; }
     public IEnumerable<string> Columns { get; }
     public int? Limit { get; }
+    public int? Offset { get; }
     public OrderByDirection? Order { get; }
     public int? BatchSize { get; }
     public string ResultFormat { get; }
 
     public ScanRequestData(string dataSource, IList<string> intervals, IFilterSpec filter, IContextSpec context,
-        IEnumerable<string> columns, string resultFormat, int? limit, OrderByDirection? order, int? batchSize)
+        IEnumerable<string> columns, string resultFormat, int? limit, int? offset, OrderByDirection? order, int? batchSize)
     {
       DataSource = dataSource;
       Intervals = intervals;
@@ -21,6 +22,7 @@ namespace Raygun.Druid4Net
       Context = context;
       Columns = columns;
       Limit = limit;
+      Offset = offset;
       Order = order;
       ResultFormat = resultFormat;
       BatchSize = batchSize;


### PR DESCRIPTION
GroupBy's [limitSpec](https://druid.apache.org/docs/latest/querying/limitspec.html#defaultlimitspec) and [Scan queries](https://druid.apache.org/docs/latest/querying/scan-query.html) both have a limit offset field.

This PR adds support for this field in both cases.

Let me know if anything needs added or amended.