### PR TITLE
Fix: Having filters incorrect keys

### DIFF
--- a/Raygun.Druid4Net.Tests/Fluent/Having/DimensionSelectorHavingSpecTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/Having/DimensionSelectorHavingSpecTests.cs
@@ -16,7 +16,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.Having
     public void Constructor_WithValues_PropertiesAreSet()
     {
       var spec = new DimensionSelectorHavingSpec("test_agg", "test_value");
-      Assert.That(spec.Aggregation, Is.EqualTo("test_agg"));
+      Assert.That(spec.Dimension, Is.EqualTo("test_agg"));
       Assert.That(spec.Value, Is.EqualTo("test_value"));
     }
   }

--- a/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/GroupByQueryDescriptorTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/GroupByQueryDescriptorTests.cs
@@ -15,7 +15,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
 
       Assert.That(request.RequestData.QueryType, Is.EqualTo("groupBy"));
     }
-    
+
     [Test]
     public void DimensionsAreSet_SetsDimensionsInBody()
     {
@@ -27,7 +27,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       Assert.That(request.RequestData.Dimensions.OfType<DefaultDimension>().FirstOrDefault(d => d.Dimension == "test_dim1"), Is.Not.Null);
       Assert.That(request.RequestData.Dimensions.OfType<DefaultDimension>().FirstOrDefault(d => d.Dimension == "test_dim2"), Is.Not.Null);
     }
-    
+
     [Test]
     public void LimitIsSet_SetsLimitInBody()
     {
@@ -66,11 +66,11 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
     public void HavingIsSet_SetsHavingInBody()
     {
       var request = new GroupByQueryDescriptor()
-        .Having(new QueryFilterHavingSpec(new SelectorFilter("test_dim1", "test_value1")))
+        .Having(new QueryFilterHavingSpec(new OrHavingSpec(new DimensionSelectorHavingSpec("test_dim1", "test_value1"))))
         .Generate();
 
-      var having = request.RequestData.HavingSpec as QueryFilterHavingSpec;
-      
+      var having = request.RequestData.Having as QueryFilterHavingSpec;
+
       Assert.IsNotNull(having);
       Assert.That(having.Type, Is.EqualTo("filter"));
       Assert.That(having.Filter, Is.Not.Null);
@@ -85,7 +85,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
         .Generate();
 
       var datasource = request.RequestData.DataSource as GroupByRequestData;
-      
+
       Assert.IsNotNull(datasource);
       Assert.That(datasource.Dimensions.Count(), Is.EqualTo(2));
       Assert.That(datasource.Dimensions.OfType<DefaultDimension>().FirstOrDefault(d => d.Dimension == "test_dim1"), Is.Not.Null);
@@ -105,7 +105,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       Assert.That(request.RequestData.Context.GroupByStrategy, Is.EqualTo("v2"));
       Assert.That(request.RequestData.Context.MaxOnDiskStorage, Is.EqualTo(10000));
     }
-    
+
     [Test]
     public void DataSourceIsSet_SetsDataSourceInBody()
     {
@@ -172,10 +172,10 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       var request = new GroupByQueryDescriptor()
         .Granularity(granularity)
         .Generate();
- 
+
       Assert.That(request.RequestData.Granularity, Is.EqualTo(expectedGranularity));
     }
-    
+
     [Test]
     public void DurationGranularitySpecIsSet_SetsGranularityInBody()
     {
@@ -183,7 +183,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       var request = new GroupByQueryDescriptor()
         .Granularity(new DurationGranularity(60, originDate))
         .Generate();
- 
+
       var granularity = request.RequestData.Granularity as DurationGranularity;
 
       Assert.IsNotNull(granularity);
@@ -191,7 +191,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       Assert.That(granularity.Duration, Is.EqualTo(60));
       Assert.That(granularity.Origin, Is.EqualTo(originDate));
     }
-    
+
     [Test]
     public void PeriodGranularitySpecIsSet_SetsGranularityInBody()
     {
@@ -199,7 +199,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       var request = new GroupByQueryDescriptor()
         .Granularity(new PeriodGranularity("PT10M", "UTC", originDate))
         .Generate();
- 
+
       var granularity = request.RequestData.Granularity as PeriodGranularity;
 
       Assert.IsNotNull(granularity);
@@ -223,7 +223,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       Assert.That(filter.Dimension, Is.EqualTo("test_dim"));
       Assert.That(filter.Value, Is.EqualTo("test_value"));
     }
-    
+
     [Test]
     public void SumAggregationIsSet_SetsAggregationInBody()
     {

--- a/Raygun.Druid4Net/Fluent/Having/DimensionSelectorHavingSpec.cs
+++ b/Raygun.Druid4Net/Fluent/Having/DimensionSelectorHavingSpec.cs
@@ -4,13 +4,13 @@
   {
     public string Type => "dimSelector";
 
-    public string Aggregation { get; }
+    public string Dimension { get; }
 
     public string Value { get; }
 
-    public DimensionSelectorHavingSpec(string aggregation, string value)
+    public DimensionSelectorHavingSpec(string dimension, string value)
     {
-      Aggregation = aggregation;
+      Dimension = dimension;
       Value = value;
     }
   }

--- a/Raygun.Druid4Net/Fluent/Having/IHavingSpec.cs
+++ b/Raygun.Druid4Net/Fluent/Having/IHavingSpec.cs
@@ -1,7 +1,6 @@
 ﻿namespace Raygun.Druid4Net
 {
-  public interface IHavingSpec
+  public interface IHavingSpec : IFilterSpec
   {
-    string Type { get; }
   }
 }

--- a/Raygun.Druid4Net/Fluent/Requests/GroupByRequestData.cs
+++ b/Raygun.Druid4Net/Fluent/Requests/GroupByRequestData.cs
@@ -7,7 +7,7 @@ namespace Raygun.Druid4Net
     public string QueryType => "groupBy";
     public IEnumerable<IDimensionSpec> Dimensions { get; }
     public ILimitSpec LimitSpec { get; }
-    public IHavingSpec HavingSpec { get; }
+    public IHavingSpec Having { get; }
     public GroupByContextSpec Context { get; }
 
     public GroupByRequestData(object dataSource, IEnumerable<ExpressionVirtualColumn> virtualColumns, object granularity, IList<string> intervals, IFilterSpec filter, GroupByContextSpec context, IEnumerable<IDimensionSpec> dimensions, IEnumerable<IAggregationSpec> aggregations, IEnumerable<IPostAggregationSpec> postAggregations, ILimitSpec limitSpec, IHavingSpec havingSpec)
@@ -22,7 +22,7 @@ namespace Raygun.Druid4Net
       Aggregations = aggregations;
       PostAggregations = postAggregations;
       LimitSpec = limitSpec;
-      HavingSpec = havingSpec;
+      Having = havingSpec;
     }
   }
 }


### PR DESCRIPTION
Info: https://druid.apache.org/docs/latest/querying/having.html#query-filters 

The Druid HavingSpec requires a key of `"having"` in order to function. The current implementation has a  key of `"havingSpec"` which is not registered in the query.

**Example:**
```
{
    "queryType": "groupBy",
    "dataSource": "sample_datasource",
    ...
    "having":
        {
            "type" : "filter",
            "filter" : <any Druid query filter>
        }
}
```

`DimSelectorHavingSpec` should have a key of `"dimension"` instead of `"aggregation"`.

**Example:**
```
{
    "queryType": "groupBy",
    "dataSource": "sample_datasource",
    ...
    "having":
        {
           "type": "or",
        "havingSpecs": [
            {
                "type": "dimSelector",
                "dimension": "uri",
                "value": "test/url/one"
            },
           {
                "type": "dimSelector",
                "dimension": "uri",
                "value": "test/url/two"
            }
        ]
    }
}
```

- Updates the `GroupByRequestData` to reflect the above example
- Updates `DimensionSelectorHavingSpec` to reflect the above example
- Allow `IHavingSpec` to be passed into `QueryFilterHavingSpec`
- Update unit tests to reflect changes