### PR TITLE
Strategy not recognised

### DIFF
--- a/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/SearchQueryDescriptorTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/SearchQueryDescriptorTests.cs
@@ -120,7 +120,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
           chunkPeriod: "PT1H",
           serializeDateTimeAsLong: true,
           serializeDateTimeAsLongInner: false,
-          searchStrategy: SearchStrategy.CursorOnly
+          searchStrategy: SearchStrategy.cursorOnly
         ).Generate();
 
       var context = request.RequestData.Context;
@@ -137,7 +137,7 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
       Assert.That(context.ChunkPeriod, Is.EqualTo("PT1H"));
       Assert.That(context.SerializeDateTimeAsLong, Is.True);
       Assert.That(context.SerializeDateTimeAsLongInner, Is.False);
-      Assert.That(context.SearchStrategy, Is.EqualTo(SearchStrategy.CursorOnly));
+      Assert.That(context.SearchStrategy, Is.EqualTo(SearchStrategy.cursorOnly));
     }
 
     [Test]

--- a/Raygun.Druid4Net/Fluent/Context/SearchStrategy.cs
+++ b/Raygun.Druid4Net/Fluent/Context/SearchStrategy.cs
@@ -5,11 +5,16 @@ namespace Raygun.Druid4Net
 		/// <summary>
 		/// First categorizes search dimensions into two groups according to their support for bitmap indexes. And then, it applies index-only and cursor-based execution plans to the group of dimensions supporting bitmaps and others, respectively
 		/// </summary>
-		UsesIndexes,
+		useIndexes,
 		
 		/// <summary>
 		/// Generates a cursor-based execution plan. This plan creates a cursor which reads a row from a queryableIndexSegment, and then evaluates search predicates. If some filters support bitmap indexes, the cursor can read only the rows which satisfy those filters, thereby saving I/O cost
 		/// </summary>
-		CursorOnly
+		cursorOnly,
+		
+		/// <summary>
+		/// Uses a cost-based planner for choosing an optimal search strategy. It estimates the cost of index-only and cursor-based execution plans, and chooses the optimal one.
+		/// </summary>
+		auto
 	}
 }

--- a/Raygun.Druid4Net/Fluent/QueryDescriptors/SearchQueryDescriptor.cs
+++ b/Raygun.Druid4Net/Fluent/QueryDescriptors/SearchQueryDescriptor.cs
@@ -97,7 +97,10 @@ namespace Raygun.Druid4Net
     {
       SetCommonContextProperties(ContextValue, timeout, maxScatterGatherBytes, priority, queryId, useCache, populateCache, bySegment, finalize, chunkPeriod, serializeDateTimeAsLong, serializeDateTimeAsLongInner);
 
-      ContextValue.SearchStrategy = searchStrategy;
+      if (searchStrategy.HasValue)
+      {
+        ContextValue.SearchStrategy = searchStrategy.Value;
+      }
       
       return this;
     }


### PR DESCRIPTION
This PR solves an issue with the search strategy not being recognized by Druid due to the JSON property being Pascal Case instead of Camel Case. We also added the `auto` strategy.