### PR TITLE
True filter and Interval filter

### DIFF
--- a/Raygun.Druid4Net.Tests/Fluent/Filters/IntervalFilterTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/Filters/IntervalFilterTests.cs
@@ -31,9 +31,19 @@ namespace Raygun.Druid4Net.Tests.Fluent.Filters
     }
     
     [Test]
-    public void Constructor_WithManyIntervals_PropertiesAreSet()
+    public void Constructor_WithManyParameterIntervals_PropertiesAreSet()
     {
       var filter = new IntervalFilter(TestDimension, TestIntervalA, TestIntervalB);
+      Assert.That(filter.Dimension, Is.EqualTo(TestDimension));
+      Assert.That(filter.Intervals.Count, Is.EqualTo(2));
+      Assert.That(filter.Intervals[0], Is.EqualTo(TestIntervalA.ToInterval()));
+      Assert.That(filter.Intervals[1], Is.EqualTo(TestIntervalB.ToInterval()));
+    }
+    
+    [Test]
+    public void Constructor_WithManyEnumerableIntervals_PropertiesAreSet()
+    {
+      var filter = new IntervalFilter(TestDimension, new []{ TestIntervalA, TestIntervalB });
       Assert.That(filter.Dimension, Is.EqualTo(TestDimension));
       Assert.That(filter.Intervals.Count, Is.EqualTo(2));
       Assert.That(filter.Intervals[0], Is.EqualTo(TestIntervalA.ToInterval()));

--- a/Raygun.Druid4Net.Tests/Fluent/Filters/IntervalFilterTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/Filters/IntervalFilterTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Raygun.Druid4Net.Fluent.Filters;
+
+namespace Raygun.Druid4Net.Tests.Fluent.Filters
+{
+  [TestFixture]
+  public class IntervalFilterTests
+  {
+    private const string TestDimension = "__time";
+
+    private static readonly Interval TestIntervalA = new Interval(DateTime.Now.Subtract(new TimeSpan(1, 0, 0)), DateTime.Now);
+    
+    private static readonly Interval TestIntervalB = new Interval(DateTime.Now.Subtract(new TimeSpan(2, 0, 0)), DateTime.Now);
+
+    [Test]
+    public void Constructor_TypeIsCorrect()
+    {
+      var filter = new IntervalFilter(TestDimension, TestIntervalA);
+      Assert.That(filter.Type, Is.EqualTo("interval"));
+    }
+    
+    [Test]
+    public void Constructor_WithSingleInterval_PropertiesAreSet()
+    {
+      var filter = new IntervalFilter(TestDimension, TestIntervalA);
+      Assert.That(filter.Dimension, Is.EqualTo(TestDimension));
+      Assert.That(filter.Intervals.Count, Is.EqualTo(1));
+      Assert.That(filter.Intervals[0], Is.EqualTo(TestIntervalA.ToInterval()));
+    }
+    
+    [Test]
+    public void Constructor_WithManyIntervals_PropertiesAreSet()
+    {
+      var filter = new IntervalFilter(TestDimension, TestIntervalA, TestIntervalB);
+      Assert.That(filter.Dimension, Is.EqualTo(TestDimension));
+      Assert.That(filter.Intervals.Count, Is.EqualTo(2));
+      Assert.That(filter.Intervals[0], Is.EqualTo(TestIntervalA.ToInterval()));
+      Assert.That(filter.Intervals[1], Is.EqualTo(TestIntervalB.ToInterval()));
+    }
+  }
+}

--- a/Raygun.Druid4Net.Tests/Fluent/Filters/TrueFilterTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/Filters/TrueFilterTests.cs
@@ -1,0 +1,16 @@
+using NUnit.Framework;
+using Raygun.Druid4Net.Fluent.Filters;
+
+namespace Raygun.Druid4Net.Tests.Fluent.Filters
+{
+    [TestFixture]
+    public class TrueFilterTests
+    {
+        [Test]
+        public void Constructor_TypeIsCorrect()
+        {
+            var filter = new TrueFilter();
+            Assert.That(filter.Type, Is.EqualTo("true"));
+        }
+    }
+}

--- a/Raygun.Druid4Net.Tests/Raygun.Druid4Net.Tests.csproj
+++ b/Raygun.Druid4Net.Tests/Raygun.Druid4Net.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Fluent\Filters\AndFilterTests.cs" />
     <Compile Include="Fluent\Filters\BoundFilterTests.cs" />
     <Compile Include="Fluent\Filters\InFilterTests.cs" />
+    <Compile Include="Fluent\Filters\IntervalFilterTests.cs" />
     <Compile Include="Fluent\Filters\JavaScriptFilterTests.cs" />
     <Compile Include="Fluent\Filters\LikeFilterTests.cs" />
     <Compile Include="Fluent\Filters\NotFilterTests.cs" />

--- a/Raygun.Druid4Net.Tests/Raygun.Druid4Net.Tests.csproj
+++ b/Raygun.Druid4Net.Tests/Raygun.Druid4Net.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Fluent\Filters\RegexFilterTests.cs" />
     <Compile Include="Fluent\Filters\SearchFilterTests.cs" />
     <Compile Include="Fluent\Filters\SelectorFilterTests.cs" />
+    <Compile Include="Fluent\Filters\TrueFilterTests.cs" />
     <Compile Include="Fluent\Granularities\DurationGranularityTests.cs" />
     <Compile Include="Fluent\Granularities\PeriodGranularityTests.cs" />
     <Compile Include="Fluent\Having\AndHavingSpecTests.cs" />

--- a/Raygun.Druid4Net/Fluent/Filters/IntervalFilter.cs
+++ b/Raygun.Druid4Net/Fluent/Filters/IntervalFilter.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Raygun.Druid4Net.Fluent.Filters
+{
+    public class IntervalFilter : IFilterSpec
+    {
+        public string Type => "interval";
+
+        public string Dimension { get; }
+
+        public List<string> Intervals { get; }
+
+        public IntervalFilter(string dimension, params Interval[] intervals)
+        {
+            Dimension = dimension;
+            Intervals = new List<string>();
+            AddIntervals(intervals);
+        }
+        
+        public IntervalFilter(string dimension, IEnumerable<Interval> intervals)
+        {
+            Dimension = dimension;
+            Intervals = new List<string>();
+            AddIntervals(intervals);
+        }
+
+        private void AddIntervals(IEnumerable<Interval> intervals)
+        {
+            foreach (var interval in intervals)
+            {
+                Intervals.Add(interval.ToInterval());
+            }
+        }
+    }
+}

--- a/Raygun.Druid4Net/Fluent/Filters/TrueFilter.cs
+++ b/Raygun.Druid4Net/Fluent/Filters/TrueFilter.cs
@@ -1,0 +1,7 @@
+namespace Raygun.Druid4Net.Fluent.Filters
+{
+    public class TrueFilter : IFilterSpec
+    {
+        public string Type => "true";
+    }
+}


### PR DESCRIPTION
I had these added in locally in my codebase, but thought I'd commit them back.

The `interval` filter, mentioned in the third example of [Filtering on the Timestamp Column](https://druid.apache.org/docs/latest/querying/filters.html#filtering-on-the-timestamp-column).

The [`true` filter](https://druid.apache.org/docs/latest/querying/filters.html#true-filter) which I use as a default filter if no others are found, and also appears to disable all other filters.