### PR TITLE
Optional limit spec

### DIFF
--- a/Raygun.Druid4Net.IntegrationTests/Queries/GroupBy/CountriesWithLimitAndOrderBy.cs
+++ b/Raygun.Druid4Net.IntegrationTests/Queries/GroupBy/CountriesWithLimitAndOrderBy.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Raygun.Druid4Net.IntegrationTests.Queries.GroupBy
+{
+  [TestFixture]
+  public class CountriesWithLimitAndOrderBy : TestQueryBase
+  {
+    private IList<QueryResult> _results;
+
+    [SetUp]
+    public void Execute()
+    {
+      var response = DruidClient.GroupBy<QueryResult>(q => q
+        .Dimensions(Wikipedia.Dimensions.CountryName)
+        .Aggregations(new LongSumAggregator("totalCount", Wikipedia.Metrics.Count))
+        .DataSource(Wikipedia.DataSource)
+        .Interval(FromDate, ToDate)
+        .Granularity(Granularities.All)
+        .Limit(new DefaultLimitSpec(10, 10, 
+          new OrderByColumnSpec(Wikipedia.Dimensions.CountryName, OrderByDirection.descending))
+        )
+      );
+
+      _results = response.Data.Select(x => x.Event).ToList();
+    }
+
+    [Test]
+    public void QueryHasCorrectNumberOfResults()
+    {
+      Assert.That(_results.Count, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void FirstResultIsCorrect()
+    {
+      Assert.That(_results.First().CountryName, Is.EqualTo("Thailand"));
+      Assert.That(_results.First().TotalCount, Is.EqualTo(8));
+    }
+
+    [Test]
+    public void LastResultIsCorrect()
+    {
+      Assert.That(_results.Last().CountryName, Is.EqualTo("South Africa"));
+      Assert.That(_results.Last().TotalCount, Is.EqualTo(4));
+    }
+
+    private class QueryResult
+    {
+      public string CountryName { get; set; }
+      public int TotalCount { get; set; }
+    }
+  }
+}

--- a/Raygun.Druid4Net.IntegrationTests/Raygun.Druid4Net.IntegrationTests.csproj
+++ b/Raygun.Druid4Net.IntegrationTests/Raygun.Druid4Net.IntegrationTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="JilSerializer.cs" />
     <Compile Include="NewtonsoftSerializer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Queries\GroupBy\CountriesWithLimitAndOrderBy.cs" />
     <Compile Include="Queries\GroupBy\PagesGroupedByCity.cs" />
     <Compile Include="Queries\Scan\ScanFilteredData.cs" />
     <Compile Include="Queries\Scan\ScanVirtualColumns.cs" />

--- a/Raygun.Druid4Net.Tests/Fluent/Limits/DefaultLimitSpecTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/Limits/DefaultLimitSpecTests.cs
@@ -16,9 +16,19 @@ namespace Raygun.Druid4Net.Tests.Fluent
     [Test]
     public void Constructor_WithAllValues_PropertiesAreSet()
     {
-      var limit = new DefaultLimitSpec(10, new OrderByColumnSpec("test_dim"));
+      var limit = new DefaultLimitSpec(10, 100, new OrderByColumnSpec("test_dim"));
       Assert.That(limit.Limit, Is.EqualTo(10));
+      Assert.That(limit.Offset, Is.EqualTo(100));
       Assert.That(limit.Columns.Count(), Is.EqualTo(1));
+      Assert.That(limit.Columns.First().Dimension, Is.EqualTo("test_dim"));
+    }
+    
+    [Test]
+    public void Constructor_WithNullValues_PropertiesAreSetAsNull()
+    {
+      var limit = new DefaultLimitSpec(new OrderByColumnSpec("test_dim"));
+      Assert.That(limit.Limit, Is.Null);
+      Assert.That(limit.Offset, Is.Null);
     }
   }
 }

--- a/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/GroupByQueryDescriptorTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/QueryDescriptors/GroupByQueryDescriptorTests.cs
@@ -29,6 +29,23 @@ namespace Raygun.Druid4Net.Tests.Fluent.QueryDescriptors
     }
 
     [Test]
+    public void LimitAndOffsetAreNull_SetsNullLimitAndOffsetInBody()
+    {
+      var request = new GroupByQueryDescriptor()
+        .Limit(new DefaultLimitSpec(new OrderByColumnSpec("test_dim1")))
+        .Generate();
+
+      var limit = request.RequestData.LimitSpec as DefaultLimitSpec;
+
+      Assert.IsNotNull(limit);
+      Assert.That(limit.Type, Is.EqualTo("default"));
+      Assert.That(limit.Limit, Is.Null);
+      Assert.That(limit.Offset, Is.Null);
+      Assert.That(limit.Columns.Count(), Is.EqualTo(1));
+      Assert.That(limit.Columns.First().Dimension, Is.EqualTo("test_dim1"));
+    }
+
+    [Test]
     public void LimitIsSet_SetsLimitInBody()
     {
       var request = new GroupByQueryDescriptor()

--- a/Raygun.Druid4Net/Fluent/Limits/DefaultLimitSpec.cs
+++ b/Raygun.Druid4Net/Fluent/Limits/DefaultLimitSpec.cs
@@ -6,20 +6,23 @@ namespace Raygun.Druid4Net
   {
     public string Type => "default";
 
-    public int Limit { get; }
-    
-    public int Offset { get; }
+    public long? Limit { get; }
+
+    public long? Offset { get; }
 
     public IEnumerable<OrderByColumnSpec> Columns { get; }
 
-    public DefaultLimitSpec(int limit, params OrderByColumnSpec[] orderByColumns)
+    public DefaultLimitSpec(params OrderByColumnSpec[] orderByColumns)
+      : this(null, null, orderByColumns)
     {
-      Limit = limit;
-      Offset = 0;
-      Columns = orderByColumns;
     }
 
-    public DefaultLimitSpec(int limit, int offset = 0, params OrderByColumnSpec[] orderByColumns)
+    public DefaultLimitSpec(long? limit = null, params OrderByColumnSpec[] orderByColumns)
+      : this(limit, 0, orderByColumns)
+    {
+    }
+
+    public DefaultLimitSpec(long? limit = null, long? offset = null, params OrderByColumnSpec[] orderByColumns)
     {
       Limit = limit;
       Offset = offset;


### PR DESCRIPTION
This PR allows the `Limit` and `Offset` in the `DefaultLimitSpec` to be null as per the [Druid documentation](https://druid.apache.org/docs/latest/querying/limitspec.html)

An integration test has also been added to verify the limit spec query.