### PR TITLE
Support BoundFilter with string values

### DIFF
--- a/Raygun.Druid4Net.IntegrationTests/Queries/Scan/BoundFilterOnMetric.cs
+++ b/Raygun.Druid4Net.IntegrationTests/Queries/Scan/BoundFilterOnMetric.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Raygun.Druid4Net.IntegrationTests.Queries.Scan
+{
+  [TestFixture]
+  public class BoundFilterOnMetric : TestQueryBase
+  {
+    private IList<QueryResult> _results;
+
+    [SetUp]
+    public void Execute()
+    {
+      var response = DruidClient.Scan<QueryResult>(q => q
+        .DataSource(Wikipedia.DataSource)
+        .Interval(FromDate, ToDate)
+        .Filter(new BoundFilter<int?>(Wikipedia.Metrics.Added, 10_000, null, lowerStrict: true, ordering: SortingOrder.numeric))
+        .Columns(Wikipedia.Metrics.Added)
+      );
+
+      _results = response.Data.SelectMany(x => x.Events).ToList();
+    }
+
+    [Test]
+    public void AllResultsHaveAddedGreaterThanTenThousand()
+    {
+      foreach (var result in _results)
+      {
+        Assert.That(result.Added, Is.GreaterThan(10_000));
+      }
+    }
+
+    private class QueryResult
+    {
+      public string Page { get; set; }
+
+      public int Added { get; set; }
+    }
+  }
+}

--- a/Raygun.Druid4Net.IntegrationTests/Raygun.Druid4Net.IntegrationTests.csproj
+++ b/Raygun.Druid4Net.IntegrationTests/Raygun.Druid4Net.IntegrationTests.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Raygun.Druid4Net.IntegrationTests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,6 +61,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Queries\GroupBy\CountriesWithLimitAndOrderBy.cs" />
     <Compile Include="Queries\GroupBy\PagesGroupedByCity.cs" />
+    <Compile Include="Queries\Scan\BoundFilterOnMetric.cs" />
     <Compile Include="Queries\Scan\ScanFilteredData.cs" />
     <Compile Include="Queries\Scan\ScanVirtualColumns.cs" />
     <Compile Include="Queries\Search\BasicSearch5Pages.cs" />

--- a/Raygun.Druid4Net.Tests/Fluent/Filters/BoundFilterTests.cs
+++ b/Raygun.Druid4Net.Tests/Fluent/Filters/BoundFilterTests.cs
@@ -9,14 +9,14 @@ namespace Raygun.Druid4Net.Tests.Fluent.Filters
     [Test]
     public void Constructor_TypeIsCorrect()
     {
-      var filter = new BoundFilter<int>("test_dimension", 10);
+      var filter = new BoundFilter<int?>("test_dimension", 10, null);
       Assert.That(filter.Type, Is.EqualTo("bound"));
     }
     
     [Test]
     public void Constructor_WithLowerValues_PropertiesAreSet()
     {
-      var filter = new BoundFilter<int>("test_dimension", 10);
+      var filter = new BoundFilter<int?>("test_dimension", 10, null);
       Assert.That(filter.Dimension, Is.EqualTo("test_dimension")); 
       Assert.That(filter.Lower, Is.EqualTo(10));
       Assert.That(filter.Upper, Is.Null);
@@ -44,6 +44,16 @@ namespace Raygun.Druid4Net.Tests.Fluent.Filters
       Assert.That(filter.Dimension, Is.EqualTo("test_dimension")); 
       Assert.That(filter.Lower, Is.EqualTo(0.1));
       Assert.That(filter.Upper, Is.EqualTo(0.2));
+    }
+    
+    [Test]
+    public void Constructor_WithStringTypeValues_PropertiesAreSet()
+    {
+      var filter = new BoundFilter<string>("test_dimension", "1", "2", ordering: SortingOrder.alphanumeric);
+      Assert.That(filter.Dimension, Is.EqualTo("test_dimension")); 
+      Assert.That(filter.Lower, Is.EqualTo("1"));
+      Assert.That(filter.Upper, Is.EqualTo("2"));
+      Assert.That(filter.Ordering, Is.EqualTo(SortingOrder.alphanumeric));
     }
   }
 }

--- a/Raygun.Druid4Net.Tests/Raygun.Druid4Net.Tests.csproj
+++ b/Raygun.Druid4Net.Tests/Raygun.Druid4Net.Tests.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Raygun.Druid4Net/Fluent/Filters/BoundFilter.cs
+++ b/Raygun.Druid4Net/Fluent/Filters/BoundFilter.cs
@@ -1,15 +1,15 @@
 ﻿
 namespace Raygun.Druid4Net
 {
-  public class BoundFilter<T> : IFilterSpec where T : struct
+  public class BoundFilter<T> : IFilterSpec
   {
     public string Type => "bound";
 
     public string Dimension { get; }
 
-    public T? Lower { get; }
+    public T Lower { get; }
 
-    public T? Upper { get; }
+    public T Upper { get; }
 
     public bool LowerStrict { get; }
 
@@ -17,7 +17,7 @@ namespace Raygun.Druid4Net
 
     public SortingOrder Ordering { get; }
 
-    public BoundFilter(string dimension, T? lower, T? upper = null, bool lowerStrict = false, bool upperStrict = false, SortingOrder ordering = SortingOrder.lexicographic)
+    public BoundFilter(string dimension, T lower, T upper, bool lowerStrict = false, bool upperStrict = false, SortingOrder ordering = SortingOrder.lexicographic)
     {
       Dimension = dimension;
       Lower = lower;

--- a/Raygun.Druid4Net/Raygun.Druid4Net.csproj
+++ b/Raygun.Druid4Net/Raygun.Druid4Net.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net45;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <PackageVersion>3.0.0</PackageVersion>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <!-- NuGet Options -->
   <PropertyGroup>


### PR DESCRIPTION
This PR updates the `BoundFilter` to work with string values to resolve #21. To support this the signature of `BoundFilter` had to change meaning this is a breaking change to existing versions. 

This will need to be released under a new major version.